### PR TITLE
Correct mount path of ConfigMap volume in cpu-pool plugin

### DIFF
--- a/deployments/cpu_pool_policy/cpu-pool-plugin-deployment.yaml
+++ b/deployments/cpu_pool_policy/cpu-pool-plugin-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: config-volume
-            mountPath: /etc/config
+            mountPath: /etc/cpu-pool-plugin-config
           - name: kubeletsockets
             mountPath: /var/lib/kubelet/cpu-plugin
       volumes:


### PR DESCRIPTION
Default path is /etc/cpu-pool-plugin-config